### PR TITLE
Update PDFMerger.php for debug range pages

### DIFF
--- a/src/Jurosh/PDFMerge/PDFMerger.php
+++ b/src/Jurosh/PDFMerge/PDFMerger.php
@@ -82,7 +82,7 @@ class PDFMerger {
                     }
                     $size = $fpdi->getTemplateSize($template);
 
-                    $fpdi->AddPage($file->getOrientationCode(), array($size['w'], $size['h']));
+                    $fpdi->AddPage($file->getOrientationCode(), array($size['width'], $size['height']));
                     $fpdi->useTemplate($template);
                 }
             }


### PR DESCRIPTION
at row 75 the good code is :
$fpdi->AddPage($file->getOrientationCode(), array($size['width'], $size['height']))

but at row 85 the size index was 'w' and 'h' that doesn't exists anymore in fpdi